### PR TITLE
Fixed text of "show template" config checkbox.

### DIFF
--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -3000,7 +3000,7 @@ Public Class MainForm
             cb.SaveAction = Sub(value) s.EnableTooltips = value
 
             cb = ui.AddCheckBox(generalPage)
-            cb.Text = "Show template selection loading new files"
+            cb.Text = "Show template selection when loading new files"
             cb.Checked = s.ShowTemplateSelection
             cb.SaveAction = Sub(value) s.ShowTemplateSelection = value
 


### PR DESCRIPTION
There was a word missing from the label, probably should be "when".

I don’t have a Visual Studio installation or any experience with VB, so i couldn’t actually test. The change seemed simple enough though.