### PR TITLE
Changed the way ffmpeg generates fake avi

### DIFF
--- a/General/Audio.vb
+++ b/General/Audio.vb
@@ -539,7 +539,7 @@ Class Audio
         If Not Package.AviSynth.VerifyOK(True) Then Throw New AbortException
 
         Dim aviPath = p.TempDir + Filepath.GetBase(ap.File) + "_cut_mm.avi"
-        Dim args = String.Format("-f lavfi -i color=c=black:s=16x16:d={0} -r {1} -y -hide_banner -c:v copy """ + aviPath + """", (p.CutFrameCount / p.CutFrameRate).ToString("f6", CultureInfo.InvariantCulture), p.CutFrameRate.ToString("f6", CultureInfo.InvariantCulture))
+        Dim args = String.Format("-f lavfi -i color=c=black:s=16x16:d={0}:r={1} -y -hide_banner -c:v copy """ + aviPath + """", (p.CutFrameCount / p.CutFrameRate).ToString("f6", CultureInfo.InvariantCulture), p.CutFrameRate.ToString("f6", CultureInfo.InvariantCulture))
 
         Using proc As New Proc
             proc.Init("Create avi file with ffmpeg " + Package.ffmpeg.Version, "frame=", "size=", "Multiple")


### PR DESCRIPTION
If you put the desired framerate of the generated clip seperately as `-r`  (like it was before), ffmpeg still applies the default framerate of 25fps because `-r` doesn't work with `-c:v copy`. This messes up cutting in mkvmerge, of course.
`:r=` (like it is now) is a suboption of `color`, which generates the correct framerate in the input file.