### PR TITLE
add FIPS compliance (use SHA512 instead of MD5)

### DIFF
--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -2232,7 +2232,7 @@ Public Class MainForm
     End Sub
 
     Function ProcessTip(message As String) As Boolean
-        CurrentAssistantTipKey = message.MD5Hash
+        CurrentAssistantTipKey = message.SHA512Hash
 
         If Not p.SkippedAssistantTips.Contains(CurrentAssistantTipKey) Then
             If message <> "" Then

--- a/General/Extensions.vb
+++ b/General/Extensions.vb
@@ -383,8 +383,8 @@ Module StringExtensions
     End Function
 
     <Extension()>
-    Function MD5Hash(value As String) As String
-        Dim crypt = MD5CryptoServiceProvider.Create()
+    Function SHA512Hash(value As String) As String
+        Dim crypt = SHA512CryptoServiceProvider.Create()
         Dim hash = crypt.ComputeHash(ASCIIEncoding.ASCII.GetBytes(value))
         Dim sb As New StringBuilder()
 


### PR DESCRIPTION
Staxrip is not FIPS compliant because MD5 is used for hashing. Changing the CryptoServiceProvider to SHA512 fixes the exception on FIPS enforced systems.